### PR TITLE
feat: support dual transport modes (stdio/socket) with static port configuration

### DIFF
--- a/packages/mutation-server-protocol/README.md
+++ b/packages/mutation-server-protocol/README.md
@@ -12,7 +12,7 @@ This document describes the mutation server protocol.
 The base protocol exchanges [JSON-RPC 2.0](https://www.jsonrpc.org/) messages between the client and the server. The protocol supports two transport modes:
 
 1. **Standard Input/Output (stdio)**
-2. **Socket connection**
+2. **TCP/IP Socket connection**
 
 The server must answer each request from the client with a response. The server may also send notifications to the client. The protocol is designed to be language agnostic and can be used with any programming language.
 


### PR DESCRIPTION
- Add support for both stdio and socket transport modes
- Servers must support both transports to ensure client compatibility
- Default to stdio transport
- Remove dynamic port selection in favor of static configuration
- Add --listen <port> and --listen <host:port> command line options for socket mode
- Default to localhost when only port is specified in --listen option
- Server must gracefully handle non-existent files or directories by ignoring them without returning errors
- Files that cannot be mutated should also be ignored during discovery and mutation testing operations

Closes #58 