### PR TITLE
feat: support dual transport modes (stdio/socket) with static port configuration

### DIFF
--- a/packages/mutation-server-protocol/README.md
+++ b/packages/mutation-server-protocol/README.md
@@ -40,11 +40,16 @@ When using socket transport:
 
 ### Server Startup Options
 
-Mutation servers must support the following command line options:
+Mutation servers must support the following command-line format:
 
-- `serve <channel>` - Specify the transport channel: `stdio` or `socket`
+```bash
+./server serve <channel> [--port <port>] [--address <address>] [-- <args>]
+```
+
+- `<channel>` - Specify the transport channel: `stdio` or `socket`. (required)
 - `--port <port>` - Port number for socket transport (required when using `socket` channel)
 - `--address <address>` - Host address for socket transport (optional, defaults to `localhost` when using `socket` channel)
+- `[-- <args>]` - Add other arguments here (mutation server specific).
 
 > [!TIP]
 > Locations are reported as part of the messages are always 1-based. The first line in a file is 1, and the first column in a line is 1.


### PR DESCRIPTION
- Add support for both stdio and socket transport modes
- Servers must support both transports to ensure client compatibility
- Remove dynamic port selection in favor of static configuration
- Added command line options to configure host and address.
- Default to localhost when only port is specified
- Server must gracefully handle non-existent files or directories by ignoring them without returning errors
- Files that cannot be mutated should also be ignored during discovery and mutation testing operations
- Closes https://github.com/stryker-mutator/editor-plugins/issues/58

Closes #58 