### PR TITLE
chore(renovate): never auto update @types/vscode

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -25,6 +25,11 @@
       "automerge": true
     },
     {
+      "matchPackageNames": ["@types/vscode"],
+      "enabled": false,
+      "description": "@types/vscode must stay in sync with engines.vscode in package.json; update manually only"
+    },
+    {
       "groupName": "Types",
       "matchPackageNames": ["@types/**"]
     },


### PR DESCRIPTION
It breaks when engines.vscode isn’t updated; ideally, this field should remain unchanged to preserve support for older versions.