### PR TITLE
build: add problemMatcher to watch:build task for tsdown

### DIFF
--- a/packages/vscode-plugin/.vscode/tasks.json
+++ b/packages/vscode-plugin/.vscode/tasks.json
@@ -20,6 +20,17 @@
       "group": "build",
       "isBackground": true,
       "label": "npm: watch:build",
+      "problemMatcher": {
+        "owner": "tsdown",
+        "pattern": {
+          "regexp": "^$"
+        },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": "Build start",
+          "endsPattern": "Rebuilt in"
+        }
+      },
       "presentation": {
         "group": "watch",
         "reveal": "never"


### PR DESCRIPTION
Launching the extension didn't work anymore after migrating to tsdown instead of esbuild in #154, because the watcher never indicated a successful initial build.